### PR TITLE
Process '+' as space in url_decode()

### DIFF
--- a/src/src/core/urlencode.cpp
+++ b/src/src/core/urlencode.cpp
@@ -46,14 +46,19 @@ std::string url_decode(std::string &src) {
     char ch;
     int i, ii;
     for (i=0; i<src.length(); i++) {
-        if (int(src[i])==37) {
+        if (src[i] == '%') {
             sscanf(src.substr(i+1,2).c_str(), "%x", &ii);
-            ch=static_cast<char>(ii);
-            ret+=ch;
-            i=i+2;
+            ch = static_cast<char>(ii);
+            ret += ch;
+            i += 2;
         } else {
-            ret+=src[i];
+            if(src[i] == '+') {
+                ret += ' ';
+            }
+            else {
+                ret += src[i];
+            }
         }
     }
-    return (ret);
+    return ret;
 }


### PR DESCRIPTION
URL encoding은 기본적으로 [RFC 3986](https://tools.ietf.org/html/rfc3986)의 Percent Encoding을 의미하나, URL에서 사용되는 의미를 볼 때, W3C에서 정의하는 [HTML 표준](https://www.w3.org/TR/html4/interact/forms.html#h-17.13.4.1)의 `application/x-www-form-urlencoded` 컨텐트로 보는 것이 합당합니다.

RFC3986의 Percent Encoding은 공백 문자(' ', ascii 0x20) %20 으로 인코딩 될 것을 상정하지만, HTML4의 표준에서는 공백 문자가 `%20`이 아닌 `+`를 이용할 것을 명시하고 있습니다.

`url_encode` 함수가 공백을 %20으로 인코딩 하는 것은 기능상 문제 없으나, `url_decode` 함수는 올바르게 인코딩된 문자열을 잘못 디코딩 할 수 있으므로 수정이 필요합니다.