### PR TITLE
Add safer methods for opening uri, avoiding using `system()`

### DIFF
--- a/src/src/core/sys_utils.cpp
+++ b/src/src/core/sys_utils.cpp
@@ -98,6 +98,20 @@ bool ftc_is_main_thread()
 }
 
 int
+ftc_open_uri(const std::string &param)
+{
+    GError *error  = NULL;
+
+    if (g_app_info_launch_default_for_uri(param.c_str(), NULL, &error)) {
+        return 0;
+    }
+
+    FTC_LOG("OPEN URI FAIL : %s", param.c_str());
+    g_error_free(error);
+
+    return 1;
+}
+int
 ftc_run_xdg_open(const std::string &param)
 {
     int rv = 0;

--- a/src/src/core/sys_utils.h
+++ b/src/src/core/sys_utils.h
@@ -12,6 +12,7 @@
 #ifndef _FTC_SYS_UTILS_H_
 #define _FTC_SYS_UTILS_H_
 
+#include <gio/gio.h>
 #include <string>
 
 std::string getIp();
@@ -23,6 +24,7 @@ unsigned long int getThreadId();
 void ftc_system_init(); 
 bool ftc_is_main_thread(); 
 int  ftc_run_xdg_open(const std::string &param);
+int  ftc_open_uri(const std::string &param);
 
 
 #endif /* _FTC_SYS_UTILS_H_ */


### PR DESCRIPTION
`ftc_run_xdg_open()` uses `system()` function to execute `xdg_open` commands. [Use of the `system()` function can result in exploitable vulnerabilities](https://wiki.sei.cmu.edu/confluence/pages/viewpage.action?pageId=87152177) such as command injection.

We can use gnome's [GAppInfo](https://developer.gnome.org/gio/stable/GAppInfo.html)'s  `g_app_info_launch_default_for_uri()` wrapper when we open uris. When we supply uri to `xdg-open`, it will call `gvfs-open`, and eventually call `g_app_info_launch_default_for_uri()`.

If we use newly implemented `ftc_open_uri()` function instead of `ftc_run_xdg_open()` to open uris, we will be much safer(avoiding usage of `system()`) and faster(reduction of control flow length).