### PR TITLE
Fix GIO stream operations bug

### DIFF
--- a/src/src/core/FileUtils.cpp
+++ b/src/src/core/FileUtils.cpp
@@ -25,8 +25,7 @@ namespace FileUtils
         GFile *file = NULL;
         GOutputStream *stream = NULL;
         GError *error = NULL;
-        unsigned int outLen = 0;
-        gsize writeBytes = 0;
+        gsize outLen = 0, writeBytes = 0;
         bool rv = false, exist = false;
 
         if (filepath == NULL || buffer == NULL) {
@@ -63,7 +62,7 @@ namespace FileUtils
                 throw 1;
             }
 
-            if (g_output_stream_write_all(stream, buffer, len, (gsize*)&outLen, NULL, &error) == false) {
+            if (g_output_stream_write_all(stream, buffer, len, &outLen, NULL, &error) == false) {
                 throw 2;
             }
 
@@ -144,7 +143,7 @@ namespace FileUtils
                 if (readBytes <= 0) {
                     break;
                 }
-                rv += buffer;
+                rv.append(buffer, readBytes);
             } while (true);
         }
         catch(const std::runtime_error& e)

--- a/src/src/core/SocketServer.cpp
+++ b/src/src/core/SocketServer.cpp
@@ -60,7 +60,7 @@ static gboolean socketServerConnectCallback(GThreadedSocketService *service,
             if (readSize <= 0) {
                 break;
             }
-            data.append(buffer);
+            data.append(buffer, readSize);
             readTotalSize += readSize;
         } while (true);
 


### PR DESCRIPTION
1. Buffer space used at g_input_stream_read() was being appended to C++ string as if it's a C-style null-terminated string (case [1](https://github.com/HuneOpenUp/ossFileTransferClient/compare/master...leesh3288:gio-stream-bugfix#diff-dc9bbb13eec46503c570d481babcb750L147), [2](https://github.com/HuneOpenUp/ossFileTransferClient/compare/master...leesh3288:gio-stream-bugfix#diff-c79f6dc6c60b093ed01257d0ba83a4f7L63)). However, [documentation](https://developer.gnome.org/gio/stable/GInputStream.html#g-input-stream-read) specifies that buffer can contain null bytes at any position as well as not necessarily being a null-terminated string. This misassumption may result in data loss or buffer over-read leading to infoleak or DoS. This is fixed by specifying the size of buffer at std::string::append.
1. [g_output_stream_write() call in http_download_file()](https://github.com/HuneOpenUp/ossFileTransferClient/compare/master...leesh3288:gio-stream-bugfix#diff-68634719cd05cef062f05f1d87d33f5fL863) does not check whether or not the requested number of bytes are actually written to the stream nor acknowledges error occurence. This is fixed by replacing the function with [g_output_stream_write_all()](https://developer.gnome.org/gio/stable/GOutputStream.html#g-output-stream-write-all) which attempts to write as many bytes as requested unless an error occurs.
1. [http_download_file()](https://github.com/HuneOpenUp/ossFileTransferClient/compare/master...leesh3288:gio-stream-bugfix?expand=1#diff-68634719cd05cef062f05f1d87d33f5fL858) now distinguishes EOF from failed stream IO, and returns success value appropriately.