### PR TITLE
fixed abnormal behavior of FileUtils::getFileNameUniqueIndex

### DIFF
--- a/src/src/core/FileUtils.cpp
+++ b/src/src/core/FileUtils.cpp
@@ -259,7 +259,9 @@ namespace FileUtils
         dir = fi.getPath();
         filename = fi.getFileName();
         extension = "." + getFileExtension(filename.c_str());
-        StringUtils::replace(filename, extension, "");
+        if (StringUtils::endsWith(filename, extension.c_str())) {
+            filename = filename.substr(0, filename.length() - extension.length());
+        }
         
         do {
             indexFilename = filename;


### PR DESCRIPTION
Originally, Ftc::Core::FileUtils::getFileNameUniqueIndex worked in abnormal way. For example, for filename "file.ext.ext", expected new name with unique index should be "file.ext(1).ext". But prior implementation get new name "file(1).ext", which discards all the nested extension name among the filename. This is fixed by taking substring of the filename, excluding only the final extension name instead of using StringUtils::replace().