### PR TITLE
Improve trimming functions

### DIFF
--- a/src/src/core/StringUtils.cpp
+++ b/src/src/core/StringUtils.cpp
@@ -24,24 +24,24 @@ BEGIN_FTC_CORE
 namespace StringUtils
 {
 
-void ltrim(std::string &s)
+void ltrim(std::string &s, char remove)
 {
-    s.erase(s.begin(), std::find_if(s.begin(), s.end(),
-                                    std::not1(std::ptr_fun<int, int>(std::isspace))));
+    s.erase(s.begin(), std::find_if(s.begin(), s.end(), [remove](int ch) {
+        return ch != remove;
+    }));
 }
 
-void rtrim(std::string &s)
+void rtrim(std::string &s, char remove)
 {
-    s.erase(std::find_if(s.rbegin(), s.rend(),
-                         std::not1(std::ptr_fun<int, int>(std::isspace)))
-                .base(),
-            s.end());
+    s.erase(std::find_if(s.rbegin(), s.rend(), [remove](int ch) {
+        return ch != remove;
+    }).base(), s.end());
 }
 
-void trim(std::string &s)
+void trim(std::string &s, char remove)
 {
-    ltrim(s);
-    rtrim(s);
+    ltrim(s, remove);
+    rtrim(s, remove);
 }
 int getInt(const std::string &s)
 {

--- a/src/src/core/StringUtils.cpp
+++ b/src/src/core/StringUtils.cpp
@@ -24,6 +24,12 @@ BEGIN_FTC_CORE
 namespace StringUtils
 {
 
+void ltrim(std::string &s)
+{
+    s.erase(s.begin(), std::find_if(s.begin(), s.end(), [](int ch) {
+        return !std::isspace(ch);
+    }));
+}
 void ltrim(std::string &s, char remove)
 {
     s.erase(s.begin(), std::find_if(s.begin(), s.end(), [remove](int ch) {
@@ -31,6 +37,12 @@ void ltrim(std::string &s, char remove)
     }));
 }
 
+void rtrim(std::string &s)
+{
+    s.erase(std::find_if(s.rbegin(), s.rend(), [](int ch) {
+        return !std::isspace(ch);
+    }).base(), s.end());
+}
 void rtrim(std::string &s, char remove)
 {
     s.erase(std::find_if(s.rbegin(), s.rend(), [remove](int ch) {
@@ -38,6 +50,11 @@ void rtrim(std::string &s, char remove)
     }).base(), s.end());
 }
 
+void trim(std::string &s)
+{
+    ltrim(s);
+    rtrim(s);
+}
 void trim(std::string &s, char remove)
 {
     ltrim(s, remove);

--- a/src/src/core/StringUtils.cpp
+++ b/src/src/core/StringUtils.cpp
@@ -26,26 +26,26 @@ namespace StringUtils
 
 void ltrim(std::string &s)
 {
-    s.erase(s.begin(), std::find_if(s.begin(), s.end(), [](int ch) {
-        return !std::isspace(ch);
+    s.erase(s.begin(), std::find_if(s.begin(), s.end(), [](char ch) {
+        return !std::isspace(static_cast<unsigned char>(ch));
     }));
 }
 void ltrim(std::string &s, char remove)
 {
-    s.erase(s.begin(), std::find_if(s.begin(), s.end(), [remove](int ch) {
+    s.erase(s.begin(), std::find_if(s.begin(), s.end(), [remove](char ch) {
         return ch != remove;
     }));
 }
 
 void rtrim(std::string &s)
 {
-    s.erase(std::find_if(s.rbegin(), s.rend(), [](int ch) {
-        return !std::isspace(ch);
+    s.erase(std::find_if(s.rbegin(), s.rend(), [](char ch) {
+        return !std::isspace(static_cast<unsigned char>(ch));
     }).base(), s.end());
 }
 void rtrim(std::string &s, char remove)
 {
-    s.erase(std::find_if(s.rbegin(), s.rend(), [remove](int ch) {
+    s.erase(std::find_if(s.rbegin(), s.rend(), [remove](char ch) {
         return ch != remove;
     }).base(), s.end());
 }

--- a/src/src/core/StringUtils.h
+++ b/src/src/core/StringUtils.h
@@ -18,9 +18,9 @@
 #include "macro.h"
 BEGIN_FTC_CORE
 namespace StringUtils {
-    void ltrim(std::string &s); 
-    void rtrim(std::string &s); 
-    void trim(std::string &s); 
+    void ltrim(std::string &s, char remove=' ');
+    void rtrim(std::string &s, char remove=' ');
+    void trim(std::string &s, char remove=' ');
     int getInt(const std::string &s); 
     int getInt(const char* s); 
     bool getBool(const std::string &s); 

--- a/src/src/core/StringUtils.h
+++ b/src/src/core/StringUtils.h
@@ -18,9 +18,12 @@
 #include "macro.h"
 BEGIN_FTC_CORE
 namespace StringUtils {
-    void ltrim(std::string &s, char remove=' ');
-    void rtrim(std::string &s, char remove=' ');
-    void trim(std::string &s, char remove=' ');
+    void ltrim(std::string &s);
+    void ltrim(std::string &s, char remove);
+    void rtrim(std::string &s);
+    void rtrim(std::string &s, char remove);
+    void trim(std::string &s);
+    void trim(std::string &s, char remove);
     int getInt(const std::string &s); 
     int getInt(const char* s); 
     bool getBool(const std::string &s); 


### PR DESCRIPTION
Now `ltrim`, `rtrim`, `trim` will have functionality for trimming every characters, not just spaces. Default behavior for these functions are to remove spaces, done by specifying default arguments.

Previous methods were only able to remove spaces, and used functions [`std::not1`](http://www.enseignement.polytechnique.fr/informatique/INF478/docs/Cpp/en/cpp/utility/functional/not1.html) and [`std::ptr_fun`](https://en.cppreference.com/w/cpp/utility/functional/ptr_fun). `std::not1` has been deprecated since C++17, and `std::ptr_fun` has been deprecated since C++11. New methods will use lambda expressions for avoiding usage of deprecated functions.