### PR TITLE
File Path 끝 부분의 "/" 다중삭제 구현, seperatePath() 수정

### DIFF
--- a/src/src/core/FileInfo.cpp
+++ b/src/src/core/FileInfo.cpp
@@ -12,6 +12,7 @@
 #include <string.h>
 
 #include "FileInfo.h"
+#include "StringUtils.h"
 
 
 #define PATH_SEPERATOR '/'
@@ -35,8 +36,10 @@ _exist(false){
 
     site = this->_fullPath.size() - 1;
     if (this->_fullPath.size() > 1 && this->_fullPath.at(site) == PATH_SEPERATOR){
-        while (_fullPath.at(--site) == PATH_SEPERATOR && site > 0);
-        this->_fullPath = this->_fullPath.substr(0, site + 1); 
+        StringUtils::rtrim(this->_fullPath, PATH_SEPERATOR);
+
+        // if _fullPath = "//////" => _fullPath = "/"
+        if (this->_fullPath.empty()) this->_fullPath = PATH_SEPERATOR;
     }
 
     
@@ -69,13 +72,10 @@ void FileInfo::seperatePath(){
 
     pos = this->_fullPath.find_last_of(PATH_SEPERATOR)    ; 
     if (pos == std::string::npos){
-        if ( this->_fullPath.size() == 0)
-            return ;
-        else {      // ex) _fullPath='file.ext' => dir: '.' , file: 'file.ext'
-            this->_path = ".";
-            this->_fileName = this->_fullPath;
-            return ;
-        } 
+        // ex) _fullPath='file.ext' => dir: '.' , file: 'file.ext'
+        this->_path = ".";
+        this->_fileName = this->_fullPath;
+        return ; 
     }
 
     this->_path = this->_fullPath.substr(0, pos); 

--- a/src/src/core/FileInfo.cpp
+++ b/src/src/core/FileInfo.cpp
@@ -26,14 +26,17 @@ FileInfo::FileInfo():_exist(false){
 FileInfo::FileInfo(const char *path) :
 _exist(false){
     int rv = 0 ; 
+    size_t site = 0 ;
     const char *tmp = nullptr ; 
     memset(&(this->_stat), 0 , sizeof(struct stat)); 
     if (path == nullptr) return ; 
     this->_fullPath = path ; 
     if (this->_fullPath.empty()) return ; 
 
-    if (this->_fullPath.size() > 1 && this->_fullPath.at(this->_fullPath.size() -1) == PATH_SEPERATOR){
-        this->_fullPath = this->_fullPath.substr(0, this->_fullPath.size() -1 ); 
+    site = this->_fullPath.size() - 1;
+    if (this->_fullPath.size() > 1 && this->_fullPath.at(site) == PATH_SEPERATOR){
+        while (_fullPath.at(--site) == PATH_SEPERATOR && site > 0);
+        this->_fullPath = this->_fullPath.substr(0, site + 1); 
     }
 
     
@@ -66,7 +69,13 @@ void FileInfo::seperatePath(){
 
     pos = this->_fullPath.find_last_of(PATH_SEPERATOR)    ; 
     if (pos == std::string::npos){
-        return ; 
+        if ( this->_fullPath.size() == 0)
+            return ;
+        else {      // ex) _fullPath='file.ext' => dir: '.' , file: 'file.ext'
+            this->_path = ".";
+            this->_fileName = this->_fullPath;
+            return ;
+        } 
     }
 
     this->_path = this->_fullPath.substr(0, pos); 


### PR DESCRIPTION
1. FileInfo의 constructor에서, _fullPath의 마지막에 '/'가 여러 개가 연속될 경우 모두 제거하도록 수정했습니다. 기존 코드는 '/'가 여러개일 경우 마지막의 '/' 한개만 제거하였습니다. 파일 경로에서 '/'는 몇 개가 있던 '/' 1개와 기능적으로 똑같으며, 프로그래머가 직접 파일 경로에 접근하므로 _fullPath에 '/'가 여러 개가 연속된 파일 경로가 들어갈 가능성이 존재합니다. 때문에 파일 경로의 마지막의 연속된 '/'는 모두 제거하도록 하였습니다. 예외적으로, '//////'와 같이 '/'만 존재할 경우 _fullPath = '/' 로 행동하도록 하였습니다.

2. FileInfo::seperatePath()에서 '/'가 없을 경우 정상 실행이 안되던 문제를 해결하였습니다. 기존 코드는 _fullPath.find_last_of(PATH_SEPARETOR)의 결과가 npos일 경우 바로 return 하기 때문에 "file.ext"와 같은 경우를 정상적으로 처리하지 못했습니다. 때문에 파일 경로에 '/'가 없더라도 파일 경로가 null이 아니라면 정상적으로 작동하게끔 수정하였습니다. 