### PR TITLE
Add null checking on EventManager::dispatchEvent

### DIFF
--- a/src/src/core/EventManager.cpp
+++ b/src/src/core/EventManager.cpp
@@ -267,6 +267,7 @@ bool EventManager::dispatchEvent(const char *eventName , void *userData) {
     if (it == this->_eventMap.end() || it->second.size() == 0) return rv ; 
 
     Event *event = Event::create(eventName, userData); 
+    if (event == nullptr) return rv;
 
     for (auto listIt = it->second.begin() ; listIt != it->second.end() ; listIt++){
         listener = *listIt ; 


### PR DESCRIPTION
`Ftc::Core::EventManager::dispatchEvent` does not check if the `Event *event` is allocated properly, and may result in null reference. Since the `Event::create` uses `new (std::nothrow)` on allocation of class Event, the return value of `Event::create` may be nullptr on case of bad allocation, thus should be checked on caller-side.