### PR TITLE
Add nullptr check on Ftc::Core::ftc_core_init()

### DIFF
--- a/src/src/core/core.cpp
+++ b/src/src/core/core.cpp
@@ -24,6 +24,7 @@ bool ftc_core_init(){
     GlobalVar::init(); 
     evtManager = EventManager::getInstance(); 
     sockServer = SocketServer::getInstance(); 
+    if (evtManager == nullptr || sockServer == nullptr) return rv;
 
     ftc_system_init();
 


### PR DESCRIPTION
`Ftc::Core::EventManager::getInstance` does not check if `new (std::nothrow) EventManager()` fails and returns `nullptr`. This function is used in `Ftc::Core::ftc_core_init`, and may cause null reference on any first dereferencing. Similarly, `Ftc::Core::SocketServer::getInstance` does not check the result of `new (std::nothrow) SocketServer()`. Added check routine of instantiation on `Ftc::Core::ftc_core_init()`.