### PR TITLE
Fixed typo, and added sanity check of instantiation on FtcEventCallback::event_source_func

### DIFF
--- a/src/src/core/Clipboard.cpp
+++ b/src/src/core/Clipboard.cpp
@@ -165,7 +165,7 @@ void Clipboard::sendThread(char *toNetwrokIp, char *sendData, unsigned int dataL
     
     try
     {
-        if (! toNetwrokIp || ! sendData || sendData <= 0) {
+        if (! toNetwrokIp || ! sendData || dataLen <= 0) {
             throw std::runtime_error("");
         }
 

--- a/src/src/ui/FtcEventCallback.cpp
+++ b/src/src/ui/FtcEventCallback.cpp
@@ -64,6 +64,7 @@ static gboolean event_source_func(gpointer data){
     EventCustom *evt = nullptr ; 
     int loopCount = 0 ; 
     Ftc::Core::EventManager *manager = Ftc::Core::EventManager::getInstance(); 
+    if (manager == nullptr) return rv;
 
     do {
         if (loopCount > 3) break ; 


### PR DESCRIPTION
Current implementation of `UI::FtcEventCallback::event_source_func` does not check the result of `Ftc::Core::EventManager::getInstance()`, which may cause null pointer dereference.
And `Core::Clipboard::sendThread()` had typo on checking `dataLen`, which can cause illegal data can bypass the checking routine. Also, the parameter name `char *toNetwrokIp` quite seems like a typo, but does not have any problem now.